### PR TITLE
Merge for publish package to nuget

### DIFF
--- a/.github/workflows/publish-nuget-jfw-sdk.yml
+++ b/.github/workflows/publish-nuget-jfw-sdk.yml
@@ -1,0 +1,37 @@
+name: Build, Test, and Publish to NuGet for package Jfw.SDK
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 6
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore src/JFW.Sdk/JFW.Sdk.csproj
+
+      - name: Build project
+        run: dotnet build JFW.Sdk/JFW.Sdk.csproj --configuration Release --no-restore
+
+      ##- name: Run tests
+      ##  run: dotnet test JFW.Sdk.Tests/JFW.Sdk.Tests.csproj --no-build --verbosity normal
+
+      - name: Pack NuGet package
+        run: dotnet pack JFW.Sdk/JFW.Sdk.csproj --configuration Release --no-build -o ./artifacts
+
+      - name: Publish to NuGet
+        if: github.event_name == 'release'
+        run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/JFW.Sdk/JFW.Sdk.csproj
+++ b/JFW.Sdk/JFW.Sdk.csproj
@@ -5,6 +5,17 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>JFW.Sdk</PackageId>
+    <Authors>1Byte Software Pte., Ltd</Authors>
+    <Company>1Byte Software Pte., Ltd</Company>
+    <AssemblyTitle>Official .NET SDK for the Jframework API</AssemblyTitle>
+    <Description>Official .NET SDK for the Jframework API</Description>
+    <Copyright>Copyright © 2021 - $([System.DateTime]::UtcNow.Year) Jframework</Copyright>
+    <RootNamespace>JFW.Sdk</RootNamespace>
+    <Version>1.0.0</Version>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <RepositoryUrl>https://github.com/1Byte-Software/jfw-sdk-dotnet.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Automated build and publishing of the SDK to NuGet for releases and manual runs, improving distribution reliability and speed.
  - Enhanced NuGet package metadata (authors, company, title, description, license, repository info, version), improving discoverability and transparency for consumers.
  - Standardized release packaging to produce consistent Release builds and artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->