### PR TITLE
fix: change destination path jfw.sdk in step restore dependency

### DIFF
--- a/.github/workflows/publish-nuget-jfw-sdk.yml
+++ b/.github/workflows/publish-nuget-jfw-sdk.yml
@@ -1,7 +1,7 @@
 name: Build, Test, and Publish to NuGet for package Jfw.SDK
 
 on:
-  pull_request:
+  push:
     branches: [ "main" ]
   release:
     types: [ published ]

--- a/.github/workflows/publish-nuget-jfw-sdk.yml
+++ b/.github/workflows/publish-nuget-jfw-sdk.yml
@@ -21,7 +21,7 @@ jobs:
           dotnet-version: 6.0.x
 
       - name: Restore dependencies
-        run: dotnet restore src/JFW.Sdk/JFW.Sdk.csproj
+        run: dotnet restore JFW.Sdk/JFW.Sdk.csproj
 
       - name: Build project
         run: dotnet build JFW.Sdk/JFW.Sdk.csproj --configuration Release --no-restore

--- a/JFW.Sdk/JFW.Sdk.csproj
+++ b/JFW.Sdk/JFW.Sdk.csproj
@@ -11,9 +11,9 @@
     <AssemblyTitle>Official .NET SDK for the Jframework API</AssemblyTitle>
     <Description>Official .NET SDK for the Jframework API</Description>
     <Copyright>Copyright © 2021 - $([System.DateTime]::UtcNow.Year) Jframework</Copyright>
-    <!-- <RootNamespace>JFW.Sdk</RootNamespace> -->
+    <RootNamespace>JFW.Sdk</RootNamespace>
     <Version>1.0.0</Version>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <!-- <PackageLicenseFile>LICENSE</PackageLicenseFile> -->
     <RepositoryUrl>https://github.com/1Byte-Software/jfw-sdk-dotnet.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>

--- a/JFW.Sdk/JFW.Sdk.csproj
+++ b/JFW.Sdk/JFW.Sdk.csproj
@@ -11,7 +11,7 @@
     <AssemblyTitle>Official .NET SDK for the Jframework API</AssemblyTitle>
     <Description>Official .NET SDK for the Jframework API</Description>
     <Copyright>Copyright © 2021 - $([System.DateTime]::UtcNow.Year) Jframework</Copyright>
-    <RootNamespace>JFW.Sdk</RootNamespace>
+    <!-- <RootNamespace>JFW.Sdk</RootNamespace> -->
     <Version>1.0.0</Version>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/1Byte-Software/jfw-sdk-dotnet.git</RepositoryUrl>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Updated CI workflow triggers to run on pushes to main and added a manual trigger.
  * Fixed the project restore path used by the NuGet publish workflow to improve build/release reliability.
  * Removed the explicit license file reference from package configuration (no functional change).
  * No changes to features or public APIs; no action required by users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->