### PR TITLE
remove condition check release event name

### DIFF
--- a/.github/workflows/publish-nuget-jfw-sdk.yml
+++ b/.github/workflows/publish-nuget-jfw-sdk.yml
@@ -1,4 +1,4 @@
-name: Build, Test, and Publish to NuGet for package Jfw.SDK
+name: Build, Test, and Publish to NuGet for package Jfw.Sdk
 
 on:
   push:
@@ -33,5 +33,4 @@ jobs:
         run: dotnet pack JFW.Sdk/JFW.Sdk.csproj --configuration Release --no-build -o ./artifacts
 
       - name: Publish to NuGet
-        if: github.event_name == 'release'
         run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized NuGet package naming to ensure consistent casing across environments.
  - Updated the publishing workflow to run on every execution, improving reliability and predictability of package availability on NuGet.
  - No changes to runtime behavior or public APIs; existing integrations are unaffected.
  - Enhances release consistency, reducing the chance of missed or delayed package updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->